### PR TITLE
Make pieces move

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -40,13 +40,44 @@ class GamesController < ApplicationController
         end
     end
 
+
     private
+
 
     def game_params
         params.required(:game).permit(:name,:player_white_id, :player_black_id)
     end
 
+    helper_method :get_piece_at_position
+    helper_method :selected_piece
     helper_method :piece_color
+    helper_method :get_piece_color
+
+    def get_piece_at_position(row, col)
+        piece = @pieces.find { |p| p.row_pos == row && p.col_pos == col}
+    end
+
+    def selected_piece(row, col)
+        piece = piece_finder(row, col)
+        if piece
+            @selected_piece = piece.type
+        else
+            @selected_piece = ""
+        end
+        @selected_piece
+    end
+
+    def get_piece_color(game, piece)
+        # handle bad data
+        return "" if game.nil? || piece.nil?
+
+        return "Black" if piece.user_id == game.player_black_id
+        return "White" if piece.user_id == game.player_white_id
+
+        # the piece is not in this game!
+        ""
+    end
+
     def piece_color(row,col)
         piece = piece_finder(row,col)
         if piece

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -50,7 +50,7 @@ class GamesController < ApplicationController
 
     helper_method :get_piece_at_position
     helper_method :selected_piece
-    helper_method :piece_color
+    helper_method :piece_color, :piece_finder
     helper_method :get_piece_color
 
     def get_piece_at_position(row, col)
@@ -93,6 +93,6 @@ class GamesController < ApplicationController
     end
 
     def piece_finder(row,col)
-        piece = @pieces.find {|p| p.row_pos == row && p.col_pos == col}
+        @pieces.find {|p| p.row_pos == row && p.col_pos == col}
     end
 end

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -6,9 +6,8 @@ class PiecesController < ApplicationController
     redirect_to game_path(piece.game)
   end
 
-  def move
- 
-      selected_piece = Piece.where(is_selected: true, user_id: current_user.id).first
+  def move    
+      selected_piece = Piece.where(is_selected: true, user_id: current_user.id).last
         if selected_piece
             square_id = params[:id].to_i
             dest_row = square_id / 8

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -3,13 +3,31 @@ class PiecesController < ApplicationController
   def select
     piece = Piece.find(params[:id])
     piece.update(is_selected: true)
-    
     redirect_to game_path(piece.game)
   end
-  
+
+  def move
+      selected_piece = Piece.where(is_selected: true, user_id: current_user.id).first
+        if selected_piece
+            square_id = params[:id].to_i
+            row = square_id / 8
+            col = square_id % 8
+
+            valid_move = true
+
+            if valid_move
+                selected_piece.row_pos = row
+                selected_piece.col_pos = col
+                selected_piece.is_selected = false
+                selected_piece.save
+            end
+        end
+        redirect_to game_path(selected_piece.game)
+  end
+
   private
 
   def piece_params
     params.required(:piece)
-  end 
+  end
 end

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -7,22 +7,21 @@ class PiecesController < ApplicationController
   end
 
   def move
+ 
       selected_piece = Piece.where(is_selected: true, user_id: current_user.id).first
         if selected_piece
             square_id = params[:id].to_i
-            row = square_id / 8
-            col = square_id % 8
+            dest_row = square_id / 8
+            dest_col = square_id % 8
 
-            valid_move = true
-
-            if valid_move
-                selected_piece.row_pos = row
-                selected_piece.col_pos = col
+            if selected_piece.valid_move?(dest_row, dest_col)
+                selected_piece.row_pos = dest_row
+                selected_piece.col_pos = dest_col
                 selected_piece.is_selected = false
                 selected_piece.save
             end
         end
-        redirect_to game_path(selected_piece.game)
+        redirect_to game_path(current_game.id)
   end
 
   private

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -21,7 +21,7 @@ class PiecesController < ApplicationController
                 selected_piece.save
             end
         end
-        redirect_to game_path(current_game.id)
+        redirect_to game_path(selected_piece.game)
   end
 
   private

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -16,30 +16,30 @@
        <tr>
         <% (0..7).each do |col| %>
        	  <td class="<%= "gray-space" if (col.even? && row.odd?) || (col.odd? && row.even?) %>">
-         <!-- find out if there is a piece in the square -->
-          
-      	    <% piece = piece_finder(row,col) %>
-    
+         <!-- find out if there is a piece in the square -->          
+          <% piece = piece_finder(row,col) %>    
           <% square_desc = "x" %>
-          <% if piece %>
-          <% square_desc = "#{piece_color(row, col)} #{piece.type}" %>
-          <% end %>
+            <% if piece %>
+              <% square_desc = "#{piece_color(row, col)} #{piece.type}" %>
+            <% end %>
           <!-- if there is a selected piece, draw move UI-->
             <% if selected_piece %>
-                <% square_id = row * 8 + col %>
-                <% if piece.nil? || piece.id != selected_piece.id %>
-                    <%= link_to square_desc, move_piece_path(square_id) %>
-                <% else %>
-                    <strong><%= square_desc %></strong>
-                <% end %>
-            <% else %>
-          <!-- there is no selected piece, draw select UI -->
-                <% if piece.present? %>
-            		  <%= link_to "#{piece_color(row,col)} #{piece.type}", select_piece_path(piece) %>
-          		<% end %>
-            <% end %>    
-        <% end %>
-        </td>
+              <% square_id = row * 8 + col %>
+              <% if piece.nil? || piece.id != selected_piece.id %>
+                <%= link_to square_desc, move_piece_path(square_id) %>
+              <% else %>
+                <strong><%= square_desc %></strong>
+              <% end %>
+            <% elsif piece %>
+          <!-- if there is a piece and it's the current user's, draw select UI -->
+              <% if piece.user_id == current_user.id %>
+            		<%= link_to square_desc, select_piece_path(piece) %> 
+          		<% else %>    
+                <%= square_desc %>
+              <% end %>                
+            <% end %>             
+          </td>
+        <% end %>  
      </tr>
  	  <% end %>
   </tbody>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -17,9 +17,9 @@
         <% (0..7).each do |col| %>
        	  <td class="<%= "gray-space" if (col.even? && row.odd?) || (col.odd? && row.even?) %>">
          <!-- find out if there is a piece in the square -->
-          <% if @pieces.select{|piece| (piece.row_pos == row && piece.col_pos == col)}.present? %>
-      	    <% piece = @pieces.select{|piece| (piece.row_pos == row && piece.col_pos == col)}[0] %>
-      	  <% end %>
+          
+      	    <% piece = piece_finder(row,col) %>
+    
           <% square_desc = "x" %>
           <% if piece %>
           <% square_desc = "#{piece_color(row, col)} #{piece.type}" %>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -3,7 +3,7 @@
 
   <h1>Game On!</h1><br />
 
-  <h2><%= @game.name %></h2><br /> 
+  <h2><%= @game.name %></h2><br />
   <p>Black</p>
   <% if @game.player_black.nil? %>
   <% else %>
@@ -11,19 +11,36 @@
   <% end %>
 <table>
   <tbody>
-    <% (0..7).each do |row| %>              
-       <tr>         
-        <% (0..7).each do |col| %>         
+    <% selected_piece = @game.pieces.select { |p| p.is_selected }.first %>
+    <% (0..7).each do |row| %>
+       <tr>
+        <% (0..7).each do |col| %>
        	  <td class="<%= "gray-space" if (col.even? && row.odd?) || (col.odd? && row.even?) %>">
+         <!-- find out if there is a piece in the square -->
           <% if @pieces.select{|piece| (piece.row_pos == row && piece.col_pos == col)}.present? %>
       	    <% piece = @pieces.select{|piece| (piece.row_pos == row && piece.col_pos == col)}[0] %>
       	  <% end %>
-      		<% if piece.present? %>	
-        		  <%= link_to "#{piece_color(row,col)} #{piece.type}", select_piece_path(piece) %>
-      		<% end %>        
-        <% end %>  
+          <% square_desc = "x" %>
+          <% if piece %>
+          <% square_desc = "#{piece_color(row, col)} #{piece.type}" %>
+          <% end %>
+          <!-- if there is a selected piece, draw move UI-->
+            <% if selected_piece %>
+                <% square_id = row * 8 + col %>
+                <% if piece.nil? || piece.id != selected_piece.id %>
+                    <%= link_to square_desc, move_piece_path(square_id) %>
+                <% else %>
+                    <strong><%= square_desc %></strong>
+                <% end %>
+            <% else %>
+          <!-- there is no selected piece, draw select UI -->
+                <% if piece.present? %>
+            		  <%= link_to "#{piece_color(row,col)} #{piece.type}", select_piece_path(piece) %>
+          		<% end %>
+            <% end %>    
+        <% end %>
         </td>
-     </tr>	
+     </tr>
  	  <% end %>
   </tbody>
 </table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,13 +3,14 @@ Chessonrails::Application.routes.draw do
   devise_for :users
   root 'games#index'
 
-  resources :games, :only => [:show, :new, :create, :update] 
+  resources :games, :only => [:show, :new, :create, :update]
 
   resources :pieces, :only => [:update] do
     member do
      get 'select'
+     get 'move'
     end
-  end 
+  end
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 


### PR DESCRIPTION
*pair programmed with @NehemiahAndrews to get this up*

There is one issue that needs to be fixed. Pieces are not tied to a game in context of move piece logic. Our hunch is that in **pieces_controller** `move` method line `selected_piece = Piece.where(is_selected: true, user_id: current_user.id).first` is selecting all the pieces for a given user across games. During the actual move process it messes up a lot of things. We are investigating how to default that line so it knows to only deal with the pieces in context of a game that is in process.

if you have any comments/ideas how to achieve, please share :small_red_triangle: 

