### PR TITLE
storing game id in a session on join

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,5 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+
 end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -21,13 +21,12 @@ class GamesController < ApplicationController
 
     def show
         @game = Game.where(:id => params[:id]).first
-        session[:current_game_id] = @game.id
         if !@game.blank?
             @pieces = @game.pieces.to_a
 	    else
             render :text => "Not found", :status => :not_found
         end
-
+        session[:current_game_id] = @game.id
     end
 
     def update

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -23,10 +23,10 @@ class GamesController < ApplicationController
         @game = Game.where(:id => params[:id]).first
         if !@game.blank?
             @pieces = @game.pieces.to_a
+            session[:current_game_id] = @game.id
 	    else
             render :text => "Not found", :status => :not_found
         end
-        session[:current_game_id] = @game.id
     end
 
     def update

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -21,11 +21,13 @@ class GamesController < ApplicationController
 
     def show
         @game = Game.where(:id => params[:id]).first
+        session[:current_game_id] = @game.id
         if !@game.blank?
             @pieces = @game.pieces.to_a
 	    else
             render :text => "Not found", :status => :not_found
         end
+
     end
 
     def update

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -6,7 +6,7 @@ class PiecesController < ApplicationController
     redirect_to game_path(piece.game)
   end
 
-  def move    
+  def move
       selected_piece = Piece.where(is_selected: true, user_id: current_user.id).last
         if selected_piece
             square_id = params[:id].to_i
@@ -20,7 +20,7 @@ class PiecesController < ApplicationController
                 selected_piece.save
             end
         end
-        redirect_to game_path(selected_piece.game)
+        redirect_to game_path(session[:current_game_id])
   end
 
   private

--- a/test/controllers/games_controller_test.rb
+++ b/test/controllers/games_controller_test.rb
@@ -77,7 +77,7 @@ class GamesControllerTest < ActionController::TestCase
       put :update, :id => game.id, :game => {:player_black_id => user.id}
       assert_redirected_to new_user_session_path
   end
-  
+
   # test "game update success" do
   #     user = FactoryGirl.create(:user)
   #     sign_in user


### PR DESCRIPTION
* As per @gruzzlymug suggestion. Storing game id in a session when you join a game

* in move method redirecting to that stored session (aka game id) the joined user is in

Still not sure if that solves our problem. I tested playing multiple games as a player and it worked for me locally. I keep tracked of game id in the url and it didn't hop in between different games like it was going before. To test please create multiple games and try to select and move pieces around and see if game id changes as you select and move pieces around.
